### PR TITLE
Refactor xUpdate for on conflict argument

### DIFF
--- a/packages/quereus/docs/plugins.md
+++ b/packages/quereus/docs/plugins.md
@@ -147,7 +147,7 @@ class MyTable extends VirtualTable {
   }
 
   // Update operations (INSERT, UPDATE, DELETE)
-  async xUpdate(operation: any, values: Row | undefined): Promise<Row | undefined> {
+  async xUpdate(operation: any, values: Row | undefined, oldKeyValues?: Row, onConflict?: ConflictResolution): Promise<Row | undefined> {
     if (operation === 'INSERT' && values) {
       this.data.push(values);
       return values;

--- a/packages/quereus/src/vtab/memory/layer/manager.ts
+++ b/packages/quereus/src/vtab/memory/layer/manager.ts
@@ -308,7 +308,8 @@ export class MemoryTableManager {
 		connection: MemoryTableConnection,
 		operation: 'insert' | 'update' | 'delete',
 		values: Row | undefined,
-		oldKeyValues?: Row
+		oldKeyValues?: Row,
+		onConflict: ConflictResolution = ConflictResolution.ABORT
 	): Promise<Row | undefined> {
 		this.validateMutationPermissions(operation);
 
@@ -316,7 +317,6 @@ export class MemoryTableManager {
 		this.ensureTransactionLayer(connection);
 
 		const targetLayer = connection.pendingTransactionLayer!;
-		const onConflict = this.extractConflictResolution(values);
 		this.cleanConflictResolutionFromValues(values);
 
 		try {
@@ -371,11 +371,12 @@ export class MemoryTableManager {
 		}
 	}
 
-	private extractConflictResolution(values: Row | undefined): ConflictResolution {
-		return (values && (values as any)._onConflict)
-			? (values as any)._onConflict as ConflictResolution
-			: ConflictResolution.ABORT;
-	}
+ 	// Deprecated: conflict resolution is now passed explicitly to performMutation
+ 	private extractConflictResolution(values: Row | undefined): ConflictResolution {
+ 		return (values && (values as any)._onConflict)
+ 			? (values as any)._onConflict as ConflictResolution
+ 			: ConflictResolution.ABORT;
+ 	}
 
 	private shouldSkipPkCheck(values: Row | undefined): boolean {
 		return !!(values && (values as any)._skipPkCheck);

--- a/packages/quereus/src/vtab/memory/table.ts
+++ b/packages/quereus/src/vtab/memory/table.ts
@@ -14,6 +14,7 @@ import { createMemoryTableLoggers } from './utils/logging.js';
 import { safeJsonStringify } from '../../util/serialization.js';
 import type { VirtualTableConnection } from '../connection.js';
 import { MemoryVirtualTableConnection } from './connection.js';
+import type { ConflictResolution } from '../../common/constants.js';
 
 const logger = createMemoryTableLoggers('table');
 
@@ -125,12 +126,13 @@ export class MemoryTable extends VirtualTable {
 	async xUpdate(
 		operation: 'insert' | 'update' | 'delete',
 		values: Row | undefined,
-		oldKeyValues?: Row
+		oldKeyValues?: Row,
+		onConflict?: ConflictResolution
 	): Promise<Row | undefined> {
 		const conn = await this.ensureConnection();
 		// Delegate mutation to the manager.
 		// This assumes manager.performMutation will be updated to this signature and logic.
-		return this.manager.performMutation(conn, operation, values, oldKeyValues);
+		return this.manager.performMutation(conn, operation, values, oldKeyValues, onConflict);
 	}
 
 	/** Begins a transaction for this connection */

--- a/packages/quereus/src/vtab/table.ts
+++ b/packages/quereus/src/vtab/table.ts
@@ -5,6 +5,7 @@ import type { MaybePromise, Row } from '../common/types.js';
 import type { IndexSchema } from '../schema/table.js';
 import type { FilterInfo } from './filter-info.js';
 import type { RowOp } from '../common/types.js';
+import type { ConflictResolution } from '../common/constants.js';
 import type { VirtualTableConnection } from './connection.js';
 import type { PlanNode } from '../planner/nodes/plan-node.js';
 
@@ -71,13 +72,15 @@ export abstract class VirtualTable {
 	 * @param operation The operation to perform (insert, update, delete)
 	 * @param values For INSERT/UPDATE, the values to insert/update. For DELETE, undefined
 	 * @param oldKeyValues For UPDATE/DELETE, the old key values of the row to modify. Undefined for INSERT
+	 * @param onConflict Conflict resolution mode (defaults to ABORT if unspecified)
 	 * @returns new row for INSERT/UPDATE, undefined for DELETE
 	 * @throws QuereusError or ConstraintError on failure
 	 */
 	abstract xUpdate(
 		operation: RowOp,
 		values: Row | undefined,
-		oldKeyValues?: Row
+		oldKeyValues?: Row,
+		onConflict?: ConflictResolution
 	): Promise<Row | undefined>;
 
 	/**

--- a/packages/quereus/test/memory-vtable.spec.ts
+++ b/packages/quereus/test/memory-vtable.spec.ts
@@ -234,11 +234,9 @@ describe("Memory VTable Module", () => {
 		it("should handle conflict resolution with INSERT OR IGNORE", async () => {
 			await table.xUpdate('insert', [1, 'user@example.com']);
 
-			// Simulate INSERT OR IGNORE by setting conflict resolution
+			// Simulate INSERT OR IGNORE by passing conflict resolution
 			const rowWithConflictRes = [1, 'other@example.com'];
-			(rowWithConflictRes as any)._onConflict = ConflictResolution.IGNORE;
-
-			const result = await table.xUpdate('insert', rowWithConflictRes);
+			const result = await table.xUpdate('insert', rowWithConflictRes, undefined, ConflictResolution.IGNORE);
 			void expect(result).to.be.undefined; // IGNORE should return undefined
 
 			// Verify original data unchanged

--- a/packages/quereus/test/vtab/test-query-module.ts
+++ b/packages/quereus/test/vtab/test-query-module.ts
@@ -5,6 +5,7 @@ import type { TableSchema } from '../../src/schema/table.js';
 import type { PlanNode } from '../../src/planner/nodes/plan-node.js';
 import { PlanNodeType } from '../../src/planner/nodes/plan-node-type.js';
 import type { Row, RowOp } from '../../src/common/types.js';
+import type { ConflictResolution } from '../../src/common/constants.js';
 import { StatusCode } from '../../src/common/types.js';
 import { IndexInfo } from '../../src/vtab/index-info.js';
 import { FilterInfo } from '../../src/vtab/filter-info.js';
@@ -122,7 +123,8 @@ export class TestQueryTable extends VirtualTable {
 	async xUpdate(
 		operation: RowOp,
 		values: Row | undefined,
-		oldKeyValues?: Row
+		oldKeyValues?: Row,
+		onConflict?: ConflictResolution
 	): Promise<Row | undefined> {
 		// Simple implementation for testing
 		switch (operation) {


### PR DESCRIPTION
Refactor `xUpdate` to accept `onConflict` as an explicit argument, removing the `_onConflict` row property for a more stable module interface.

---
<a href="https://cursor.com/background-agent?bcId=bc-694e90c0-465b-4448-9d64-c97ba212b5de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-694e90c0-465b-4448-9d64-c97ba212b5de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

